### PR TITLE
Allow override the defaultValidators

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -73,7 +73,8 @@ var Field = Concur.extend({
     messages.push(kwargs.errorMessages)
     this.errorMessages = object.extend.apply(object, messages)
 
-    this.validators = this.defaultValidators.concat(kwargs.validators)
+    // Allow override the defaultValidators
+    this.validators = kwargs.validators || this.this.defaultValidators
   }
 })
 


### PR DESCRIPTION
Ex: override message
```
const LoginForm = forms.Form.extend({
    email: forms.EmailField({validators: [EmailValidator({message:'my customize email invalid msg'})] }),
    password: forms.CharField({widget: forms.PasswordInput})
  }
)
```